### PR TITLE
Direction operators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,12 @@ jobs:
   linux-ubuntu:
     strategy:
       matrix:
-        cc: [gcc, clang]
+        cxx: [g++, clang++]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GIT repo
         uses: actions/checkout@v4
       - name: Build Deq executable
-        run: make CXX="${{ matrix.cc }}"
+        run: make CXX="${{ matrix.cxx }}"
       - name: Run testing
         run: ./rere.py replay ./test.list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Checkout GIT repo
         uses: actions/checkout@v4
       - name: Build Deq executable
-        run: make
+        run: make CXX="${{ matrix.cc }}"
       - name: Run testing
         run: ./rere.py replay ./test.list

--- a/REF.md
+++ b/REF.md
@@ -35,6 +35,7 @@
 - `putc` ( c -- ) -- prints `c` as character to stdout
 - `calldir` ( -- dir ) -- pushes 1 if label was called with left direction, 0 otherwise
 - `invertdir` ( -- newinverted ) -- pushes new value of `inverted` flag and flips it effectively inverting directions of all subsequent operations
+- `setinverted` ( invertflag -- ) -- sets value of `inverted` flag
 
 ## Not directional
 - `trace` -- print current deque state

--- a/REF.md
+++ b/REF.md
@@ -33,6 +33,8 @@
 - `print` ( a -- ) -- print any element (works with all types)
 - `println` ( a -- ) -- `print`, but also prints life-feed (aka new-line) at the end
 - `putc` ( c -- ) -- prints `c` as character to stdout
+- `calldir` ( -- dir ) -- pushes 1 if label was called with left direction, 0 otherwise
+- `invertdir` ( -- newinverted ) -- pushes new value of `inverted` flag and flips it effectively inverting directions of all subsequent operations
 
 ## Not directional
 - `trace` -- print current deque state

--- a/deq.cpp
+++ b/deq.cpp
@@ -715,6 +715,13 @@ static void interpret(const std::vector<Token>& tox, bool debug = false)
             push({ token, static_cast<s64>(left) });
 
             i++;
+        } else if (word == "setinverted") {
+            expect(1);
+            deq_t v = pop();
+            DIAG(typecheck<1>({ v }, { Integer }));
+            inverted = static_cast<bool>(std::get<s64>(v.as));
+
+            i++;
         } else {
             if (labels.contains(word)) {
                 push({ token, static_cast<s64>(labels.at(word)) });

--- a/tests/calldir.deq
+++ b/tests/calldir.deq
@@ -1,0 +1,14 @@
+proc! call!
+!proc !call
+
+exit
+proc:
+    "Called with "! print!
+    calldir! 0! eq! proc.right! jnz!
+    "left"! print!
+    !proc.over !jmp
+proc.right:
+    "right"! print!
+proc.over:
+    " direction"! println!
+    ret

--- a/tests/invert.deq
+++ b/tests/invert.deq
@@ -1,0 +1,15 @@
+# Strange test. In both cases result should be the same (except for `inverted`
+# flag value ofc)
+!invertdir
+outputTest! call!
+
+0! dup! setinverted!
+outputTest! call!
+
+exit
+outputTest:
+    69! 1337!
+    !println
+    println!
+    !println
+    ret


### PR DESCRIPTION
#Direction operators(aka DO) operate on how to interpret the direction of subsequent operations, or they can provide these interpreter flags to the user.

This PR implements 2 new DO-s (already in PR's Language Reference):
- `invertdir` - inverts direction
- `calldir` - pushes the direction of last `call` operation